### PR TITLE
Proxy all api requests to the backend server

### DIFF
--- a/client/nginx/nginx.conf
+++ b/client/nginx/nginx.conf
@@ -7,6 +7,12 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    location /api/ {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_pass http://server:5000/api/;
+    }
+
     error_page  500 502 503 504  /50x.html;
 
     location = /50x.html {


### PR DESCRIPTION
Fixes #12 Problem lied in the nginx config not routing connections to your backbend server 
Note: the "server" in the config needs to match the name of your backend server in the docker-compose file